### PR TITLE
Implement RequestExtensions for http::request::Parts

### DIFF
--- a/reset-router/src/lib.rs
+++ b/reset-router/src/lib.rs
@@ -609,29 +609,21 @@ impl<S: 'static + Send + Sync + Clone, Ctx> hyper::service::MakeService<Ctx> for
 struct State<S>(pub S);
 struct MatchingRegex(Arc<Regex>);
 
-/// Base extensions to `http::Request` and `http::request::Parts` to support access to captures
-pub trait RequestCaptureExtensions {
+/// Extensions to `http::Request` and `http::request::Parts` to support easy access to captures and `State` object
+pub trait RequestExtensions {
     /// Any captures provided by the matching `Regex` for the current path
     fn captures(&self) -> Option<Captures>;
-}
-
-/// Extensions to `http::Request` and `http::request::Parts` to support easy access to captures and `State` object
-pub trait RequestExtensions : RequestCaptureExtensions {
     /// Positional captures parsed into `FromStr` types, in tuple format
-    fn parsed_captures<C: ParsableCapture>(&self) -> err::Result<C>;
+    fn parsed_captures<C: FromCaptures>(&self) -> err::Result<C> {
+        Ok(C::from_captures(self.captures())?)
+    }
     /// Copy of any state passed into the router builder using `with_state`
     fn state<S: Send + Sync + 'static>(&self) -> Option<Arc<S>>;
 }
 
-impl RequestCaptureExtensions for Request {
+impl RequestExtensions for Request {
     fn captures(&self) -> Option<Captures> {
         self.extensions().get::<MatchingRegex>().and_then(|r| r.0.captures(self.uri().path()))
-    }
-}
-
-impl RequestExtensions for Request {
-    fn parsed_captures<C: ParsableCapture>(&self) -> err::Result<C> {
-        Ok(C::from_request(self)?)
     }
 
     fn state<S: Send + Sync + 'static>(&self) -> Option<Arc<S>> {
@@ -639,15 +631,9 @@ impl RequestExtensions for Request {
     }
 }
 
-impl RequestCaptureExtensions for http::request::Parts {
+impl RequestExtensions for http::request::Parts {
     fn captures(&self) -> Option<Captures> {
         self.extensions.get::<MatchingRegex>().and_then(|r| r.0.captures(self.uri.path()))
-    }
-}
-
-impl RequestExtensions for http::request::Parts {
-    fn parsed_captures<C: ParsableCapture>(&self) -> err::Result<C> {
-        Ok(C::from_request(self)?)
     }
 
     fn state<S: Send + Sync + 'static>(&self) -> Option<Arc<S>> {
@@ -656,13 +642,13 @@ impl RequestExtensions for http::request::Parts {
 }
 
 /// Implemented for `T: FromStr` tups up to 4
-pub trait ParsableCapture: Sized {
-    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self>;
+pub trait FromCaptures: Sized {
+    fn from_captures(caps: Option<Captures>) -> err::Result<Self>;
 }
 
-impl<U: FromStr> ParsableCapture for (U,) {
-    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
-        let captures = req.captures().ok_or(err::Error::Captures)?;
+impl<U: FromStr> FromCaptures for (U,) {
+    fn from_captures(caps: Option<Captures>) -> err::Result<Self> {
+        let captures = caps.ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
             .map(|x| x.as_str())
@@ -672,9 +658,9 @@ impl<U: FromStr> ParsableCapture for (U,) {
     }
 }
 
-impl<U1: FromStr, U2: FromStr> ParsableCapture for (U1, U2) {
-    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
-        let captures = req.captures().ok_or(err::Error::Captures)?;
+impl<U1: FromStr, U2: FromStr> FromCaptures for (U1, U2) {
+    fn from_captures(caps: Option<Captures>) -> err::Result<Self> {
+        let captures = caps.ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
             .map(|x| x.as_str())
@@ -689,9 +675,9 @@ impl<U1: FromStr, U2: FromStr> ParsableCapture for (U1, U2) {
     }
 }
 
-impl<U1: FromStr, U2: FromStr, U3: FromStr> ParsableCapture for (U1, U2, U3) {
-    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
-        let captures = req.captures().ok_or(err::Error::Captures)?;
+impl<U1: FromStr, U2: FromStr, U3: FromStr> FromCaptures for (U1, U2, U3) {
+    fn from_captures(caps: Option<Captures>) -> err::Result<Self> {
+        let captures = caps.ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
             .map(|x| x.as_str())
@@ -711,9 +697,9 @@ impl<U1: FromStr, U2: FromStr, U3: FromStr> ParsableCapture for (U1, U2, U3) {
     }
 }
 
-impl<U1: FromStr, U2: FromStr, U3: FromStr, U4: FromStr> ParsableCapture for (U1, U2, U3, U4) {
-    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
-        let captures = req.captures().ok_or(err::Error::Captures)?;
+impl<U1: FromStr, U2: FromStr, U3: FromStr, U4: FromStr> FromCaptures for (U1, U2, U3, U4) {
+    fn from_captures(caps: Option<Captures>) -> err::Result<Self> {
+        let captures = caps.ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
             .map(|x| x.as_str())

--- a/reset-router/src/lib.rs
+++ b/reset-router/src/lib.rs
@@ -609,37 +609,59 @@ impl<S: 'static + Send + Sync + Clone, Ctx> hyper::service::MakeService<Ctx> for
 struct State<S>(pub S);
 struct MatchingRegex(Arc<Regex>);
 
-/// Extensions to `http::Request` to support easy access to captures and `State` object
-pub trait RequestExtensions {
+/// Base extensions to `http::Request` and `http::request::Parts` to support access to captures
+pub trait RequestCaptureExtensions {
+    /// Any captures provided by the matching `Regex` for the current path
     fn captures(&self) -> Option<Captures>;
+}
+
+/// Extensions to `http::Request` and `http::request::Parts` to support easy access to captures and `State` object
+pub trait RequestExtensions : RequestCaptureExtensions {
+    /// Positional captures parsed into `FromStr` types, in tuple format
     fn parsed_captures<C: ParsableCapture>(&self) -> err::Result<C>;
+    /// Copy of any state passed into the router builder using `with_state`
     fn state<S: Send + Sync + 'static>(&self) -> Option<Arc<S>>;
 }
 
-impl RequestExtensions for Request {
-    /// Any captures provided by the matching `Regex` for the current path
+impl RequestCaptureExtensions for Request {
     fn captures(&self) -> Option<Captures> {
         self.extensions().get::<MatchingRegex>().and_then(|r| r.0.captures(self.uri().path()))
     }
+}
 
-    /// Positional captures parsed into `FromStr` types, in tuple format
+impl RequestExtensions for Request {
     fn parsed_captures<C: ParsableCapture>(&self) -> err::Result<C> {
         Ok(C::from_request(self)?)
     }
 
-    /// Copy of any state passed into the router builder using `with_state`
     fn state<S: Send + Sync + 'static>(&self) -> Option<Arc<S>> {
         self.extensions().get::<State<Arc<S>>>().as_ref().map(|x| x.0.clone())
     }
 }
 
+impl RequestCaptureExtensions for http::request::Parts {
+    fn captures(&self) -> Option<Captures> {
+        self.extensions.get::<MatchingRegex>().and_then(|r| r.0.captures(self.uri.path()))
+    }
+}
+
+impl RequestExtensions for http::request::Parts {
+    fn parsed_captures<C: ParsableCapture>(&self) -> err::Result<C> {
+        Ok(C::from_request(self)?)
+    }
+
+    fn state<S: Send + Sync + 'static>(&self) -> Option<Arc<S>> {
+        self.extensions.get::<State<Arc<S>>>().as_ref().map(|x| x.0.clone())
+    }
+}
+
 /// Implemented for `T: FromStr` tups up to 4
 pub trait ParsableCapture: Sized {
-    fn from_request(req: &Request) -> err::Result<Self>;
+    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self>;
 }
 
 impl<U: FromStr> ParsableCapture for (U,) {
-    fn from_request(req: &Request) -> err::Result<Self> {
+    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
         let captures = req.captures().ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
@@ -651,7 +673,7 @@ impl<U: FromStr> ParsableCapture for (U,) {
 }
 
 impl<U1: FromStr, U2: FromStr> ParsableCapture for (U1, U2) {
-    fn from_request(req: &Request) -> err::Result<Self> {
+    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
         let captures = req.captures().ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
@@ -668,7 +690,7 @@ impl<U1: FromStr, U2: FromStr> ParsableCapture for (U1, U2) {
 }
 
 impl<U1: FromStr, U2: FromStr, U3: FromStr> ParsableCapture for (U1, U2, U3) {
-    fn from_request(req: &Request) -> err::Result<Self> {
+    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
         let captures = req.captures().ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)
@@ -690,7 +712,7 @@ impl<U1: FromStr, U2: FromStr, U3: FromStr> ParsableCapture for (U1, U2, U3) {
 }
 
 impl<U1: FromStr, U2: FromStr, U3: FromStr, U4: FromStr> ParsableCapture for (U1, U2, U3, U4) {
-    fn from_request(req: &Request) -> err::Result<Self> {
+    fn from_request(req: &dyn RequestCaptureExtensions) -> err::Result<Self> {
         let captures = req.captures().ok_or(err::Error::Captures)?;
         let out_1 = captures
             .get(1)


### PR DESCRIPTION
This allows accessing `state` and `parsed_captures` on the `http::request::Parts` object returned by `Request::into_parts`, which is useful when parsing the body of the request.

This requires splitting the `RequestExtensions` trait into a base trait `RequestCaptureExtensions` and itself, so `RequestCaptureExtensions` can be turned into a trait object and passed to methods that just require access to the `captures()` method, such as `ParsableCapture::from_request`.